### PR TITLE
Add tagged mod output block & block telemetry features

### DIFF
--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -8,5 +8,6 @@
 
 install(FILES
     openlst_openlst_mod.block.yml
+    openlst_openlst_mod_tagged.block.yml
     openlst_openlst_demod.block.yml DESTINATION share/gnuradio/grc/blocks
 )

--- a/grc/openlst_openlst_demod.block.yml
+++ b/grc/openlst_openlst_demod.block.yml
@@ -4,7 +4,7 @@ category: '[openlst]'
 
 templates:
   imports: from gnuradio import openlst
-  make: openlst.openlst_demod(client_format=${client_format}, preamble_quality=${preamble_quality}, fec=${fec}, whitening=${whitening})
+  make: openlst.openlst_demod(client_format=${client_format}, preamble_quality=${preamble_quality}, fec=${fec}, whitening=${whitening}, debug=${debug})
 
 parameters:
 - id: preamble_quality
@@ -25,6 +25,10 @@ parameters:
   options: [ "'CLIENT_PACKET'", "'RAW'" ]
   option_labels: [ CLIENT_PACKET, RAW ]
   default: "'CLIENT_PACKET'"
+- id: debug
+  label: Debug
+  dtype: bool
+  default: 'False'
 
 inputs:
 - label: in
@@ -33,5 +37,8 @@ inputs:
 outputs:
 - label: message
   domain: message
+- label: debug
+  domain: message
+  optional: true
 
 file_format: 1

--- a/grc/openlst_openlst_demod.block.yml
+++ b/grc/openlst_openlst_demod.block.yml
@@ -27,7 +27,9 @@ parameters:
   default: "'CLIENT_PACKET'"
 - id: debug
   label: Debug
-  dtype: bool
+  dtype: enum
+  options: ['True', 'False']
+  option_labels: ['Enabled', 'Disabled']
   default: 'False'
 
 inputs:

--- a/grc/openlst_openlst_mod.block.yml
+++ b/grc/openlst_openlst_mod.block.yml
@@ -31,7 +31,9 @@ parameters:
   default: "'CLIENT_PACKET'"
 - id: debug
   label: Debug
-  dtype: bool
+  dtype: enum
+  options: ['True', 'False']
+  option_labels: ['Enabled', 'Disabled']
   default: 'False'
 
 inputs:

--- a/grc/openlst_openlst_mod.block.yml
+++ b/grc/openlst_openlst_mod.block.yml
@@ -4,7 +4,7 @@ category: '[openlst]'
 
 templates:
   imports: from gnuradio import openlst
-  make: openlst.openlst_mod(client_format=${client_format}, fec=${fec}, whitening=${whitening}, bitrate=${bitrate}, max_latency=${max_latency})
+  make: openlst.openlst_mod(client_format=${client_format}, fec=${fec}, whitening=${whitening}, bitrate=${bitrate}, max_latency=${max_latency}, debug=${debug})
 
 parameters:
 - id: fec
@@ -29,6 +29,10 @@ parameters:
   options: [ "'CLIENT_PACKET'", "'RAW'" ]
   option_labels: [ CLIENT_PACKET, RAW ]
   default: "'CLIENT_PACKET'"
+- id: debug
+  label: Debug
+  dtype: bool
+  default: 'False'
 
 inputs:
 - label: message
@@ -37,5 +41,8 @@ inputs:
 outputs:
 - label: out
   dtype: byte
+- label: debug
+  domain: message
+  optional: true
 
 file_format: 1

--- a/grc/openlst_openlst_mod_tagged.block.yml
+++ b/grc/openlst_openlst_mod_tagged.block.yml
@@ -39,7 +39,9 @@ parameters:
   default: "'CLIENT_PACKET'"
 - id: debug
   label: Debug
-  dtype: bool
+  dtype: enum
+  options: ['True', 'False']
+  option_labels: ['Enabled', 'Disabled']
   default: 'False'
 
 inputs:

--- a/grc/openlst_openlst_mod_tagged.block.yml
+++ b/grc/openlst_openlst_mod_tagged.block.yml
@@ -1,0 +1,49 @@
+id: openlst_openlst_mod_tagged
+label: OpenLST Frame+Encode (Tagged)
+category: '[openlst]'
+
+templates:
+  imports: from gnuradio import openlst
+  make: openlst.openlst_mod_tagged(client_format=${client_format}, fec=${fec}, whitening=${whitening}, length_tag_name=${length_tag_name}, samples_per_symbol=${samples_per_symbol}, resample_ratio=${resample_ratio}, padding_bytes=${padding_bytes})
+
+parameters:
+- id: fec
+  label: Enable FEC
+  dtype: bool
+  default: true
+- id: whitening
+  label: Enable data whitening
+  dtype: bool
+  default: true
+- id: length_tag_name
+  label: Length Tag Name
+  dtype: string
+  default: "packet_len"
+- id: samples_per_symbol
+  label: Samples Per Symbol
+  dtype: int
+  default: 2
+- id: resample_ratio
+  label: Resample Ratio
+  dtype: float
+  default: 1.0
+- id: padding_bytes
+  label: Padding Bytes
+  dtype: int
+  default: 2
+- id: client_format
+  label: Client message format
+  dtype: enum
+  options: [ "'CLIENT_PACKET'", "'RAW'" ]
+  option_labels: [ CLIENT_PACKET, RAW ]
+  default: "'CLIENT_PACKET'"
+
+inputs:
+- label: message
+  domain: message
+
+outputs:
+- label: out
+  dtype: byte
+
+file_format: 1

--- a/grc/openlst_openlst_mod_tagged.block.yml
+++ b/grc/openlst_openlst_mod_tagged.block.yml
@@ -4,7 +4,7 @@ category: '[openlst]'
 
 templates:
   imports: from gnuradio import openlst
-  make: openlst.openlst_mod_tagged(client_format=${client_format}, fec=${fec}, whitening=${whitening}, length_tag_name=${length_tag_name}, samples_per_symbol=${samples_per_symbol}, resample_ratio=${resample_ratio}, padding_bytes=${padding_bytes})
+  make: openlst.openlst_mod_tagged(client_format=${client_format}, fec=${fec}, whitening=${whitening}, length_tag_name=${length_tag_name}, samples_per_symbol=${samples_per_symbol}, resample_ratio=${resample_ratio}, padding_bytes=${padding_bytes}, debug=${debug})
 
 parameters:
 - id: fec
@@ -37,6 +37,10 @@ parameters:
   options: [ "'CLIENT_PACKET'", "'RAW'" ]
   option_labels: [ CLIENT_PACKET, RAW ]
   default: "'CLIENT_PACKET'"
+- id: debug
+  label: Debug
+  dtype: bool
+  default: 'False'
 
 inputs:
 - label: message
@@ -45,5 +49,8 @@ inputs:
 outputs:
 - label: out
   dtype: byte
+- label: debug
+  domain: message
+  optional: true
 
 file_format: 1

--- a/python/openlst/CMakeLists.txt
+++ b/python/openlst/CMakeLists.txt
@@ -23,6 +23,7 @@ GR_PYTHON_INSTALL(
     FILES
     __init__.py
     openlst_mod.py
+    openlst_mod_tagged.py
     openlst_demod.py DESTINATION ${GR_PYTHON_DIR}/gnuradio/openlst
 )
 

--- a/python/openlst/__init__.py
+++ b/python/openlst/__init__.py
@@ -21,5 +21,6 @@ except ModuleNotFoundError:
 
 # import any pure python here
 from .openlst_mod import openlst_mod
+from .openlst_mod_tagged import openlst_mod_tagged
 from .openlst_demod import openlst_demod
 #

--- a/python/openlst/openlst_demod.py
+++ b/python/openlst/openlst_demod.py
@@ -127,8 +127,8 @@ class openlst_demod(gr.sync_block):
                         logger.info(f'[demod] sync word detected #{self.sync_detected}')
                         self.message_port_pub(pmt.intern('debug'), pmt.to_pmt({
                             'event': 'sync_detected',
-                            'sync_num': self.sync_detected,
-                            'preamble_quality': matched if 'matched' in dir() else 0,
+                            'sync_num': int(self.sync_detected),
+                            'preamble_quality': int(matched) if 'matched' in dir() else 0,
                         }))
                     if self.fec:
                         self._mode = 'lengthfec'
@@ -247,7 +247,7 @@ class openlst_demod(gr.sync_block):
                 self.message_port_pub(pmt.intern('debug'), pmt.to_pmt({
                     'event': 'decode_error',
                     'reason': str(sp.err()),
-                    'packets_dropped': self.packets_dropped,
+                    'packets_dropped': int(self.packets_dropped),
                 }))
             raise ValueError(f'SpacePacket validation error: {sp.err()}')
 
@@ -275,11 +275,11 @@ class openlst_demod(gr.sync_block):
             logger.info(f'[demod] packet decoded #{self.packets_decoded}: length={self._length}, seq={sp.header.sequence_number}, dst={sp.header.destination}, cmd={sp.header.command_number}')
             self.message_port_pub(pmt.intern('debug'), pmt.to_pmt({
                 'event': 'decoded',
-                'pkt_num': self.packets_decoded,
-                'length': self._length,
-                'seq': sp.header.sequence_number,
-                'dst': sp.header.destination,
-                'cmd': sp.header.command_number,
+                'pkt_num': int(self.packets_decoded),
+                'length': int(self._length),
+                'seq': int(sp.header.sequence_number),
+                'dst': int(sp.header.destination),
+                'cmd': int(sp.header.command_number),
             }))
 
 

--- a/python/openlst/openlst_demod.py
+++ b/python/openlst/openlst_demod.py
@@ -19,7 +19,7 @@ from satcom.openlst.fec import decode_fec_chunk
 from satcom.openlst.whitening import pn9, whiten
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class openlst_demod(gr.sync_block):
@@ -43,6 +43,7 @@ class openlst_demod(gr.sync_block):
         preamble_quality=30,
         fec=True,
         whitening=True,
+        debug=False,
     ):
         gr.sync_block.__init__(
             self,
@@ -52,10 +53,14 @@ class openlst_demod(gr.sync_block):
         )
         self.message_port_register_out(pmt.intern('message'))
 
+        # Debug/telemetry output port
+        self.message_port_register_out(pmt.intern('debug'))
+
         self.preamble_quality = preamble_quality
         self.fec = fec
         self.whitening = whitening
         self.client_format = client_format
+        self.debug = debug
 
         # map the preamble into a list of integers representing each bit
         self.preamble_bits = [int(i) for i in ''.join([bin(byt)[2:] for byt in space_packet_lib.SPACE_PACKET_PREAMBLE])]
@@ -66,9 +71,18 @@ class openlst_demod(gr.sync_block):
         self._length = 0
         self._sync_bits_len = len(space_packet_lib.SPACE_PACKET_ASM) * 8
 
+        # Telemetry counters
+        self.preambles_detected = 0
+        self.sync_detected = 0
+        self.sync_missed = 0
+        self.packets_decoded = 0
+        self.packets_dropped = 0
+        self.bytes_processed = 0
+
     def work(self, input_items, output_items):
         # Each input byte is actually one LSB-encoded bit
         self._buff.extend(input_items[0])
+        self.bytes_processed += len(input_items[0])
 
         # Work through as much of the buffer as possible, stopping
         # when it is clear no forward progress is being made
@@ -91,6 +105,9 @@ class openlst_demod(gr.sync_block):
 
                 # indicates a preamble match of required quality or better
                 if self._buff[0] == 1 and matched >= self.preamble_quality:
+                    self.preambles_detected += 1
+                    if self.debug:
+                        logger.info(f'[demod] preamble detected #{self.preambles_detected}: matched {matched}/{len(self.preamble_bits)} bits')
                     break
 
                 # continue searching through buffer
@@ -105,14 +122,27 @@ class openlst_demod(gr.sync_block):
                     bitcast(syncbuff[i:i + 8]) for i in range(0, self._sync_bits_len, 8)
                 ])
                 if sw == space_packet_lib.SPACE_PACKET_ASM:
+                    self.sync_detected += 1
+                    if self.debug:
+                        logger.info(f'[demod] sync word detected #{self.sync_detected}')
+                        self.message_port_pub(pmt.intern('debug'), pmt.to_pmt({
+                            'event': 'sync_detected',
+                            'sync_num': self.sync_detected,
+                            'preamble_quality': matched if 'matched' in dir() else 0,
+                        }))
                     if self.fec:
                         self._mode = 'lengthfec'
                     else:
                         self._mode = 'length'
                     self._buff = syncbuff[self._sync_bits_len:]
+                    if self.debug:
+                        logger.debug(f'[demod] state: search -> {self._mode}')
 
                 # no direct match, so will retrigger search process
                 else:
+                    self.sync_missed += 1
+                    if self.debug:
+                        logger.debug(f'[demod] sync missed (preamble matched but sync word failed), total missed: {self.sync_missed}')
                     self._buff.pop(0)
 
         # Wait for the length byte (potentially whitened)
@@ -125,6 +155,8 @@ class openlst_demod(gr.sync_block):
                 self._length = length_byte
                 self._mode = 'data'
                 self._buff = self._buff[8:]
+                if self.debug:
+                    logger.debug(f'[demod] state: length -> data, packet_length={self._length}')
 
         # Wait for two chunks of FECed content to decode the length byte
         elif self._mode == 'lengthfec':
@@ -159,6 +191,8 @@ class openlst_demod(gr.sync_block):
                 self._fecbuff = b[1:]
                 self._mode = 'datafec'
                 self._buff = self._buff[64:]
+                if self.debug:
+                    logger.debug(f'[demod] state: lengthfec -> datafec, packet_length={self._length}')
 
         elif self._mode == 'data':
             # In non-FEC mode we just decode one byte at a time
@@ -207,6 +241,14 @@ class openlst_demod(gr.sync_block):
     def handle_space_packet(self, data: bytearray):
         sp = space_packet_lib.SpacePacket.from_bytes(bytes([self._length]) + data)
         if sp.err():
+            self.packets_dropped += 1
+            if self.debug:
+                logger.warning(f'[demod] packet dropped #{self.packets_dropped}: {sp.err()}')
+                self.message_port_pub(pmt.intern('debug'), pmt.to_pmt({
+                    'event': 'decode_error',
+                    'reason': str(sp.err()),
+                    'packets_dropped': self.packets_dropped,
+                }))
             raise ValueError(f'SpacePacket validation error: {sp.err()}')
 
         if self.client_format == 'CLIENT_PACKET':
@@ -227,6 +269,18 @@ class openlst_demod(gr.sync_block):
 
         output_pmt = pmt.init_u8vector(len(output_b), list(output_b))
         self.message_port_pub(pmt.intern('message'), output_pmt)
+
+        self.packets_decoded += 1
+        if self.debug:
+            logger.info(f'[demod] packet decoded #{self.packets_decoded}: length={self._length}, seq={sp.header.sequence_number}, dst={sp.header.destination}, cmd={sp.header.command_number}')
+            self.message_port_pub(pmt.intern('debug'), pmt.to_pmt({
+                'event': 'decoded',
+                'pkt_num': self.packets_decoded,
+                'length': self._length,
+                'seq': sp.header.sequence_number,
+                'dst': sp.header.destination,
+                'cmd': sp.header.command_number,
+            }))
 
 
 def bitcast(bitlist):

--- a/python/openlst/openlst_mod.py
+++ b/python/openlst/openlst_mod.py
@@ -143,10 +143,10 @@ class openlst_mod(gr.sync_block):
             logger.info(f'[mod] message encoded #{self.messages_encoded}: {len(output_b)} bytes, queue_depth={len(self._msg_buffer)}')
             self.message_port_pub(pmt.intern('debug'), pmt.to_pmt({
                 'event': 'encoded',
-                'msg_num': self.messages_encoded,
-                'input_bytes': len(input_b),
-                'output_bytes': len(output_b),
-                'queue_depth': len(self._msg_buffer),
+                'msg_num': int(self.messages_encoded),
+                'input_bytes': int(len(input_b)),
+                'output_bytes': int(len(output_b)),
+                'queue_depth': int(len(self._msg_buffer)),
             }))
 
     def work(self, input_items, output_items):

--- a/python/openlst/openlst_mod.py
+++ b/python/openlst/openlst_mod.py
@@ -6,16 +6,20 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-import pmt
+import logging
 import time
+
+import pmt
 import numpy as np
-import logging as logger
 from gnuradio import gr
 
 from satcom.openlst import client_packet_lib
 from satcom.openlst import space_packet_lib
 from satcom.openlst.fec import encode_fec
 from satcom.openlst.whitening import whiten
+
+
+logger = logging.getLogger(__name__)
 
 
 class openlst_mod(gr.sync_block):
@@ -44,6 +48,7 @@ class openlst_mod(gr.sync_block):
             whitening=True,
             bitrate=7415.77,
             max_latency=0.1,
+            debug=False,
         ):
         gr.sync_block.__init__(
             self,
@@ -55,9 +60,13 @@ class openlst_mod(gr.sync_block):
         self.message_port_register_in(pmt.intern('message'))
         self.set_msg_handler(pmt.intern('message'), self.handle_msg)
 
+        # Debug/telemetry output port
+        self.message_port_register_out(pmt.intern('debug'))
+
         self.fec = fec
         self.whitening = whitening
         self.client_format = client_format
+        self.debug = debug
 
         self._msg_buffer = []
         self._partial = False
@@ -73,17 +82,28 @@ class openlst_mod(gr.sync_block):
         self._bytes_sent = 0
         self._last_buff_check = None
 
+        # Telemetry counters
+        self.messages_received = 0
+        self.messages_encoded = 0
+        self.messages_dropped = 0
+
     def handle_msg(self, msg):
         input_b = bytes(pmt.to_python(msg))
+        self.messages_received += 1
+
+        if self.debug:
+            logger.info(f'[mod] message received #{self.messages_received}: {len(input_b)} bytes, format={self.client_format}')
 
         if self.client_format == 'CLIENT_PACKET':
             try:
                 cp = client_packet_lib.ClientPacket.from_bytes(input_b)
             except Exception:
+                self.messages_dropped += 1
                 logger.exception('failed parsing client packet from input message, discarding')
                 return
 
             if cp.err():
+                self.messages_dropped += 1
                 logger.error(f'ClientPacket validation error: {cp.err()}')
                 return
 
@@ -117,6 +137,17 @@ class openlst_mod(gr.sync_block):
 
         # Queue encoded message for transmission
         self._msg_buffer.append((time.time(), list(output_b)))
+        self.messages_encoded += 1
+
+        if self.debug:
+            logger.info(f'[mod] message encoded #{self.messages_encoded}: {len(output_b)} bytes, queue_depth={len(self._msg_buffer)}')
+            self.message_port_pub(pmt.intern('debug'), pmt.to_pmt({
+                'event': 'encoded',
+                'msg_num': self.messages_encoded,
+                'input_bytes': len(input_b),
+                'output_bytes': len(output_b),
+                'queue_depth': len(self._msg_buffer),
+            }))
 
     def work(self, input_items, output_items):
         if self._last_buff_check is None:

--- a/python/openlst/openlst_mod_tagged.py
+++ b/python/openlst/openlst_mod_tagged.py
@@ -7,9 +7,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+import logging
+
 import pmt
 import numpy as np
-import logging as logger
 from gnuradio import gr
 
 from satcom.openlst import client_packet_lib
@@ -18,24 +19,27 @@ from satcom.openlst.fec import encode_fec
 from satcom.openlst.whitening import whiten
 
 
+logger = logging.getLogger(__name__)
+
+
 class openlst_mod_tagged(gr.sync_block):
     """
     OpenLST Encoder/Framer (Tagged Stream)
 
     This block accepts Gnuradio Messages containing complete OpenLST client
-    frames. It translates each frame into a corresponding space frame, 
-    applies whitening/FEC, adds preamble/sync words, and outputs it as 
+    frames. It translates each frame into a corresponding space frame,
+    applies whitening/FEC, adds preamble/sync words, and outputs it as
     a tagged stream.
 
     Burst Handling:
-    - A length tag (default: "packet_len") is added to the first item of 
+    - A length tag (default: "packet_len") is added to the first item of
       each packet.
-    - The tag value is scaled to match the expected number of SAMPLES at 
+    - The tag value is scaled to match the expected number of SAMPLES at
       the USRP sink.
-    - Zero-byte padding is appended to the end of the packet to flush 
+    - Zero-byte padding is appended to the end of the packet to flush
       downstream filters.
-    
-    NOTE: This block assumes the output buffer provided by the scheduler 
+
+    NOTE: This block assumes the output buffer provided by the scheduler
     is large enough to hold the entire encoded packet at once.
     """
     def __init__(
@@ -46,7 +50,8 @@ class openlst_mod_tagged(gr.sync_block):
             length_tag_name="packet_len",
             samples_per_symbol=2,
             resample_ratio=1.0,
-            padding_bytes=2
+            padding_bytes=2,
+            debug=False,
         ):
         gr.sync_block.__init__(
             self,
@@ -54,37 +59,53 @@ class openlst_mod_tagged(gr.sync_block):
             in_sig=None,
             out_sig=[np.uint8],
         )
-        
+
         # Messages arrive in raw form without a length or CRC
         self.message_port_register_in(pmt.intern('message'))
         self.set_msg_handler(pmt.intern('message'), self.handle_msg)
 
+        # Debug/telemetry output port
+        self.message_port_register_out(pmt.intern('debug'))
+
         self.fec = fec
         self.whitening = whitening
         self.client_format = client_format
-        
+        self.debug = debug
+
         # Tagging setup
         self.length_tag_key = pmt.intern(length_tag_name)
-        
+
         # Flush/Padding setup
         self.padding_bytes = padding_bytes
-        
+
         # Output Scaling Calculation:
         self.output_scaling = 8.0 * samples_per_symbol / resample_ratio
 
         self._msg_buffer = []
 
+        # Telemetry counters
+        self.messages_received = 0
+        self.messages_encoded = 0
+        self.messages_dropped = 0
+        self.bytes_output = 0
+
     def handle_msg(self, msg):
         input_b = bytes(pmt.to_python(msg))
+        self.messages_received += 1
+
+        if self.debug:
+            logger.info(f'[mod_tagged] message received #{self.messages_received}: {len(input_b)} bytes, format={self.client_format}')
 
         if self.client_format == 'CLIENT_PACKET':
             try:
                 cp = client_packet_lib.ClientPacket.from_bytes(input_b)
             except Exception:
+                self.messages_dropped += 1
                 logger.exception('failed parsing client packet from input message, discarding')
                 return
 
             if cp.err():
+                self.messages_dropped += 1
                 logger.error(f'ClientPacket validation error: {cp.err()}')
                 return
 
@@ -117,28 +138,43 @@ class openlst_mod_tagged(gr.sync_block):
 
         # Prepend Preamble and Sync Word (ASM)
         output_b = space_packet_lib.SPACE_PACKET_PREAMBLE + space_packet_lib.SPACE_PACKET_ASM + output_b
-        
+
         # Append Padding (Flush downstream filters)
         if self.padding_bytes > 0:
             output_b += bytes([0] * self.padding_bytes)
 
         # Queue encoded message
         self._msg_buffer.append(list(output_b))
+        self.messages_encoded += 1
+
+        if self.debug:
+            tag_samples = int(np.ceil(len(output_b) * self.output_scaling)) + 1
+            logger.info(f'[mod_tagged] message encoded #{self.messages_encoded}: {len(output_b)} bytes, tag_samples={tag_samples}, queue_depth={len(self._msg_buffer)}')
+            self.message_port_pub(pmt.intern('debug'), pmt.to_pmt({
+                'event': 'encoded',
+                'msg_num': self.messages_encoded,
+                'input_bytes': len(input_b),
+                'output_bytes': len(output_b),
+                'tag_samples': tag_samples,
+                'queue_depth': len(self._msg_buffer),
+            }))
 
     def work(self, input_items, output_items):
         if len(self._msg_buffer) > 0:
             msg = self._msg_buffer[0]
-            
+
             # --- TAGGING ---
             nwritten = self.nitems_written(0)
-            
+
             # Calculate the burst length in SAMPLES for the USRP
-            final_length_samples = int(np.ceil(len(msg) * self.output_scaling))
-            
+            # +1 accounts for the mmse_resampler producing one extra sample
+            # from its internal phase accumulator
+            final_length_samples = int(np.ceil(len(msg) * self.output_scaling)) + 1
+
             self.add_item_tag(
-                0, 
-                nwritten, 
-                self.length_tag_key, 
+                0,
+                nwritten,
+                self.length_tag_key,
                 pmt.from_long(final_length_samples)
             )
 
@@ -146,13 +182,14 @@ class openlst_mod_tagged(gr.sync_block):
             # Safety check: ensure we don't overflow the buffer provided by GR
             # (Assumes buffer is large enough for the full packet as requested)
             n_out = min(len(output_items[0]), len(msg))
-            
+
             output_items[0][:n_out] = msg[:n_out]
 
             # --- CLEANUP ---
             # Remove the message from the queue immediately
             self._msg_buffer.pop(0)
 
+            self.bytes_output += n_out
             return n_out
-            
+
         return 0

--- a/python/openlst/openlst_mod_tagged.py
+++ b/python/openlst/openlst_mod_tagged.py
@@ -70,7 +70,7 @@ class openlst_mod_tagged(gr.sync_block):
         self.padding_bytes = padding_bytes
         
         # Output Scaling Calculation:
-        self.output_scaling = 8.0 * samples_per_symbol * resample_ratio
+        self.output_scaling = 8.0 * samples_per_symbol / resample_ratio
 
         self._msg_buffer = []
 

--- a/python/openlst/openlst_mod_tagged.py
+++ b/python/openlst/openlst_mod_tagged.py
@@ -152,11 +152,11 @@ class openlst_mod_tagged(gr.sync_block):
             logger.info(f'[mod_tagged] message encoded #{self.messages_encoded}: {len(output_b)} bytes, tag_samples={tag_samples}, queue_depth={len(self._msg_buffer)}')
             self.message_port_pub(pmt.intern('debug'), pmt.to_pmt({
                 'event': 'encoded',
-                'msg_num': self.messages_encoded,
-                'input_bytes': len(input_b),
-                'output_bytes': len(output_b),
-                'tag_samples': tag_samples,
-                'queue_depth': len(self._msg_buffer),
+                'msg_num': int(self.messages_encoded),
+                'input_bytes': int(len(input_b)),
+                'output_bytes': int(len(output_b)),
+                'tag_samples': int(tag_samples),
+                'queue_depth': int(len(self._msg_buffer)),
             }))
 
     def work(self, input_items, output_items):
@@ -167,9 +167,7 @@ class openlst_mod_tagged(gr.sync_block):
             nwritten = self.nitems_written(0)
 
             # Calculate the burst length in SAMPLES for the USRP
-            # +1 accounts for the mmse_resampler producing one extra sample
-            # from its internal phase accumulator
-            final_length_samples = int(np.ceil(len(msg) * self.output_scaling)) + 1
+            final_length_samples = int(np.ceil(len(msg) * self.output_scaling))
 
             self.add_item_tag(
                 0,

--- a/python/openlst/openlst_mod_tagged.py
+++ b/python/openlst/openlst_mod_tagged.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2023 Robert Zimmerman.
+# Copyright 2024 Antaris Inc.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import pmt
+import numpy as np
+import logging as logger
+from gnuradio import gr
+
+from satcom.openlst import client_packet_lib
+from satcom.openlst import space_packet_lib
+from satcom.openlst.fec import encode_fec
+from satcom.openlst.whitening import whiten
+
+
+class openlst_mod_tagged(gr.sync_block):
+    """
+    OpenLST Encoder/Framer (Tagged Stream)
+
+    This block accepts Gnuradio Messages containing complete OpenLST client
+    frames. It translates each frame into a corresponding space frame, 
+    applies whitening/FEC, adds preamble/sync words, and outputs it as 
+    a tagged stream.
+
+    Burst Handling:
+    - A length tag (default: "packet_len") is added to the first item of 
+      each packet.
+    - The tag value is scaled to match the expected number of SAMPLES at 
+      the USRP sink.
+    - Zero-byte padding is appended to the end of the packet to flush 
+      downstream filters.
+    
+    NOTE: This block assumes the output buffer provided by the scheduler 
+    is large enough to hold the entire encoded packet at once.
+    """
+    def __init__(
+            self,
+            client_format,
+            fec=True,
+            whitening=True,
+            length_tag_name="packet_len",
+            samples_per_symbol=2,
+            resample_ratio=1.0,
+            padding_bytes=2
+        ):
+        gr.sync_block.__init__(
+            self,
+            name="OpenLST Encode (Tagged)",
+            in_sig=None,
+            out_sig=[np.uint8],
+        )
+        
+        # Messages arrive in raw form without a length or CRC
+        self.message_port_register_in(pmt.intern('message'))
+        self.set_msg_handler(pmt.intern('message'), self.handle_msg)
+
+        self.fec = fec
+        self.whitening = whitening
+        self.client_format = client_format
+        
+        # Tagging setup
+        self.length_tag_key = pmt.intern(length_tag_name)
+        
+        # Flush/Padding setup
+        self.padding_bytes = padding_bytes
+        
+        # Output Scaling Calculation:
+        self.output_scaling = 8.0 * samples_per_symbol * resample_ratio
+
+        self._msg_buffer = []
+
+    def handle_msg(self, msg):
+        input_b = bytes(pmt.to_python(msg))
+
+        if self.client_format == 'CLIENT_PACKET':
+            try:
+                cp = client_packet_lib.ClientPacket.from_bytes(input_b)
+            except Exception:
+                logger.exception('failed parsing client packet from input message, discarding')
+                return
+
+            if cp.err():
+                logger.error(f'ClientPacket validation error: {cp.err()}')
+                return
+
+            sp = space_packet_lib.SpacePacket(
+                header=space_packet_lib.SpacePacketHeader(
+                    sequence_number=cp.header.sequence_number,
+                    destination=cp.header.destination,
+                    command_number=cp.header.command_number
+                ),
+                data=cp.data,
+                footer=space_packet_lib.SpacePacketFooter(
+                    hardware_id=cp.header.hardware_id,
+                ),
+            )
+
+        elif self.client_format == 'RAW':
+            sp = space_packet_lib.SpacePacket(
+                data=input_b,
+            )
+        else:
+            raise ValueError('invalid client_format')
+
+        output_b = sp.to_bytes()
+
+        # Apply Physical Layer processing
+        if self.whitening:
+            output_b = whiten(output_b)
+        if self.fec:
+            output_b = encode_fec(output_b)
+
+        # Prepend Preamble and Sync Word (ASM)
+        output_b = space_packet_lib.SPACE_PACKET_PREAMBLE + space_packet_lib.SPACE_PACKET_ASM + output_b
+        
+        # Append Padding (Flush downstream filters)
+        if self.padding_bytes > 0:
+            output_b += bytes([0] * self.padding_bytes)
+
+        # Queue encoded message
+        self._msg_buffer.append(list(output_b))
+
+    def work(self, input_items, output_items):
+        if len(self._msg_buffer) > 0:
+            msg = self._msg_buffer[0]
+            
+            # --- TAGGING ---
+            nwritten = self.nitems_written(0)
+            
+            # Calculate the burst length in SAMPLES for the USRP
+            final_length_samples = int(np.ceil(len(msg) * self.output_scaling))
+            
+            self.add_item_tag(
+                0, 
+                nwritten, 
+                self.length_tag_key, 
+                pmt.from_long(final_length_samples)
+            )
+
+            # --- WRITING ---
+            # Safety check: ensure we don't overflow the buffer provided by GR
+            # (Assumes buffer is large enough for the full packet as requested)
+            n_out = min(len(output_items[0]), len(msg))
+            
+            output_items[0][:n_out] = msg[:n_out]
+
+            # --- CLEANUP ---
+            # Remove the message from the queue immediately
+            self._msg_buffer.pop(0)
+
+            return n_out
+            
+        return 0


### PR DESCRIPTION
Added a new block that tags outputs appropriately for bursty transmission. takes into account the downstream resampling so sample count with the tag is correct when it reaches the SDR sink. Also added configurable debug output to all blocks for future telemetry purposes.